### PR TITLE
Slightly better mod support

### DIFF
--- a/utils/RCBot2_meta/bot_fortress.cpp
+++ b/utils/RCBot2_meta/bot_fortress.cpp
@@ -2214,7 +2214,7 @@ void CBotTF2 :: updateClass ()
 		else if ( strcmp(model,"demoman") )
 			m_iClass = TF_CLASS_DEMOMAN;
 		else
-			m_iClass = TF_CLASS_CIVILIAN;
+			m_iClass = TF_CLASS_UNDEFINED;
 			*/
 
 		m_fUpdateClass = 0.0f;

--- a/utils/RCBot2_meta/bot_fortress.h
+++ b/utils/RCBot2_meta/bot_fortress.h
@@ -235,7 +235,7 @@ typedef enum
 
 typedef enum
 {
-	TF_CLASS_CIVILIAN = 0,
+	TF_CLASS_UNDEFINED = 0,
 	TF_CLASS_SCOUT,
 	TF_CLASS_SNIPER,
 	TF_CLASS_SOLDIER,
@@ -494,7 +494,7 @@ public:
 
 	void chooseClass ();
 
-	virtual TF_Class getClass () { return TF_CLASS_CIVILIAN; }
+	virtual TF_Class getClass () { return TF_CLASS_UNDEFINED; }
 
 	virtual void updateClass () { };
 

--- a/utils/RCBot2_meta/bot_globals.cpp
+++ b/utils/RCBot2_meta/bot_globals.cpp
@@ -38,6 +38,7 @@
 #include "bot_weapons.h"
 
 #include "ndebugoverlay.h"
+#include "filesystem.h"
 
 #include "logging.h"
 
@@ -194,22 +195,10 @@ void CBotGlobals::readRCBotFolder()
 	KeyValues *mainkv = new KeyValues("Metamod Plugin");
 
 	if (mainkv->LoadFromFile(filesystem, "addons/metamod/rcbot2.vdf", "MOD")) {
-		char folder[256] = "\0";
 		const char *szRCBotFolder = mainkv->GetString("rcbot2path");
 
 		if (szRCBotFolder && *szRCBotFolder) {
 			logger->Log(LogLevel::INFO, "RCBot Folder -> trying %s", szRCBotFolder);
-
-			if (!dirExists(szRCBotFolder)) {
-				snprintf(folder, sizeof folder, "%s/%s", CBotGlobals::modFolder(), szRCBotFolder);
-
-				szRCBotFolder = CStrings::getString(folder);
-				logger->Log(LogLevel::INFO, "RCBot Folder -> trying %s", szRCBotFolder);
-
-				if (!dirExists(szRCBotFolder)) {
-					logger->Log(LogLevel::ERROR, "RCBot Folder -> not found ...");
-				}
-			}
 
 			m_szRCBotFolder = CStrings::getString(szRCBotFolder);
 		}
@@ -1135,6 +1124,9 @@ void CBotGlobals :: buildFileName ( char *szOutput, const char *szFile, const ch
 		strcat(szOutput,".");
 		strcat(szOutput,szExtension);
 	}
+
+	if (m_szRCBotFolder != NULL)
+		filesystem->RelativePathToFullPath(szOutput, NULL, szOutput, 512, FILTER_CULLPACK);
 }
 
 QAngle CBotGlobals::playerAngles ( edict_t *pPlayer )

--- a/utils/RCBot2_meta/bot_mods.cpp
+++ b/utils/RCBot2_meta/bot_mods.cpp
@@ -239,15 +239,13 @@ void CBotMods :: readMods()
 	#elif SOURCE_ENGINE == SE_SDK2013
 		m_Mods.emplace_back(new CSynergyMod());
 	#else
-
 		m_Mods.emplace_back(new CFortressForeverMod());
 
 		m_Mods.emplace_back(new CHLDMSourceMod());
-
-		// Look for extra MODs
-
-		parseFile();
 	#endif
+	// Look for extra MODs
+	
+	parseFile();
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/utils/RCBot2_meta/bot_task.cpp
+++ b/utils/RCBot2_meta/bot_task.cpp
@@ -2654,7 +2654,7 @@ void CSpyCheckAir :: execute ( CBot *pBot, CBotSchedule *pSchedule )
 		pBot->setMoveTo(CBotGlobals::entityOrigin(m_pUnseenBefore));
 	}
 /*
-	TF_CLASS_CIVILIAN = 0,
+	TF_CLASS_UNDEFINED = 0,
 	TF_CLASS_SCOUT,
 	TF_CLASS_SNIPER,
 	TF_CLASS_SOLDIER,


### PR DESCRIPTION
* use engine functions to find rcbot2, instead of manually checking for it from wherever the engine is running. fixes issues with running rcbot2 as a sourcemod on steam.
* load config file no matter what engine it is using, otherwise it can be broken for certain mods (example, metamod thinks tf2classic runs on the tf2 engine!)
* renamed TF_CLASS_CIVILIAN because it isn't even pointing to the actual "civilian" class' id