### PR TITLE
Stops bot to attack with specific tf2 conditions

### DIFF
--- a/utils/RCBot2_meta/bot_fortress.cpp
+++ b/utils/RCBot2_meta/bot_fortress.cpp
@@ -7502,22 +7502,18 @@ bool CBotTF2::isEnemy(edict_t* pEdict, const bool bCheckWeapons)
 	{
 		if ( CBotGlobals::getTeam(pEdict) != getTeam() )
 		{
-			//TODO: To prevent bots from shooting at ghost players - like in plr_hightower_event Hell Zone [APG]RoboCop[CL]
-			/*if (pEdict != nullptr && CBotGlobals::entityIsValid(pEdict)) {
+			//TODO: To prevent bots from shooting at ghost players - like in plr_hightower_event Hell Zone [APG]RoboCop[CL] -> RE: I don't know why this code was disabled when it works fine with bots. Bots ignore anyone who has 77th and 51th tf2 conditions - RussiaTails
+			if (CTF2Conditions::TF2_IsPlayerInCondition(edictIndex, TFCond_UberchargedHidden))
+			return false; // Don't attack MvM bots who are inside spawn.
+						
+			if (CTF2Conditions::TF2_IsPlayerInCondition(edictIndex, TFCond_HalloweenGhostMode))
+			return false; // Don't attack Ghost Players
+			if (pEdict != nullptr && CBotGlobals::entityIsValid(pEdict)) {
 
 				if (pEdict != nullptr && CBotGlobals::entityIsValid(pEdict)) {
 					const int edictIndex = engine->IndexOfEdict(pEdict);
-					if (CTF2Conditions::TF2_IsPlayerInCondition(edictIndex, TFCond_UberchargedHidden)) {
-						// Don't attack MvM bots who are inside spawn.
-						return false;
 					}
-
-					if (CTF2Conditions::TF2_IsPlayerInCondition(edictIndex, TFCond_HalloweenGhostMode)) {
-						// Don't attack Ghost Players
-						return false;
-					}
-				}
-			}*/
+			}
 			
 			if ( m_iClass == TF_CLASS_SPY )	
 			{


### PR DESCRIPTION
Enables cut function by [APG]RoboCop[CL] of bots stopping attack anyone who has "TFCond_UberchargedHidden" and "TFCond_HalloweenGhostMode" tf2 conditions

Proof in demo files from arena_lumberyard_event and plr_hightower_event
[test of 77th condition.zip](https://github.com/user-attachments/files/18677610/test.of.77th.condition.zip)
