### PR TITLE
Versus Saxton Hale + Pipeball support

### DIFF
--- a/utils/RCBot2_meta/bot_fortress.cpp
+++ b/utils/RCBot2_meta/bot_fortress.cpp
@@ -4464,9 +4464,9 @@ void CBotTF2 :: getTasks ( unsigned iIgnore )
 			pWaypointResupply = CWaypoints::getWaypoint(CWaypoints::getClosestFlagged(CWaypointTypes::W_FL_RESUPPLY, vOrigin, iTeam, &fResupplyDist, failedlist));
 
 		if ( bNeedAmmo )
-			pWaypointAmmo = CWaypoints::getWaypoint(CWaypoints::getClosestFlagged(CWaypointTypes::W_FL_AMMO,vOrigin,iTeam,&fAmmoDist,failedlist));
+			pWaypointAmmo = CWaypoints::getWaypoint(CWaypoints::getClosestFlagged(CWaypointTypes::W_FL_AMMO,vOrigin,getTeam(),&fAmmoDist,failedlist));
 		if ( bNeedHealth )
-			pWaypointHealth = CWaypoints::getWaypoint(CWaypoints::getClosestFlagged(CWaypointTypes::W_FL_HEALTH,vOrigin,iTeam,&fHealthDist,failedlist));
+			pWaypointHealth = CWaypoints::getWaypoint(CWaypoints::getClosestFlagged(CWaypointTypes::W_FL_HEALTH,vOrigin,getTeam(),&fHealthDist,failedlist));
 	}
 
 	if ( iClass == TF_CLASS_ENGINEER )
@@ -4812,6 +4812,7 @@ void CBotTF2 :: getTasks ( unsigned iIgnore )
 			(CTeamFortress2Mod::isMapType(TF_MAP_SD)||CTeamFortress2Mod::isMapType(TF_MAP_CART)||
 			CTeamFortress2Mod::isMapType(TF_MAP_CARTRACE)||
 			(CTeamFortress2Mod::isMapType(TF_MAP_ARENA)&&CTeamFortress2Mod::isArenaPointOpen())||
+			(CTeamFortress2Mod::isMapType(TF_MAP_SAXTON)&&CTeamFortress2Mod::isArenaPointOpen())||
 			(CTeamFortress2Mod::isMapType(TF_MAP_KOTH)&&CTeamFortress2Mod::isArenaPointOpen())||
 			CTeamFortress2Mod::isMapType(TF_MAP_CP)||CTeamFortress2Mod::isMapType(TF_MAP_CPPL)||CTeamFortress2Mod::isMapType(TF_MAP_TC)),fGetFlagUtility)
 
@@ -4819,7 +4820,7 @@ void CBotTF2 :: getTasks ( unsigned iIgnore )
 	// (!CTeamFortress2Mod::isAttackDefendMap()||(m_iTeam==TF2_TEAM_RED))
 	ADD_UTILITY(BOT_UTIL_DEFEND_POINT, (m_iCurrentDefendArea>0) && 
 		(CTeamFortress2Mod::isMapType(TF_MAP_MVM)||CTeamFortress2Mod::isMapType(TF_MAP_SD)||CTeamFortress2Mod::isMapType(TF_MAP_CART)||
-		CTeamFortress2Mod::isMapType(TF_MAP_CARTRACE)||CTeamFortress2Mod::isMapType(TF_MAP_ARENA)||
+		CTeamFortress2Mod::isMapType(TF_MAP_CARTRACE)||CTeamFortress2Mod::isMapType(TF_MAP_ARENA)||CTeamFortress2Mod::isMapType(TF_MAP_SAXTON)||
 		CTeamFortress2Mod::isMapType(TF_MAP_KOTH)||CTeamFortress2Mod::isMapType(TF_MAP_CP)|| CTeamFortress2Mod::isMapType(TF_MAP_CPPL)||
 		CTeamFortress2Mod::isMapType(TF_MAP_TC))&&m_iClass!=TF_CLASS_SCOUT,fDefendFlagUtility)
 
@@ -4967,7 +4968,7 @@ void CBotTF2 :: getTasks ( unsigned iIgnore )
 
 		ADD_UTILITY(BOT_UTIL_DEMO_STICKYTRAP_POINT, (iTeam == TF2_TEAM_RED) && (m_iCurrentDefendArea>0) &&
 			(CTeamFortress2Mod::isMapType(TF_MAP_MVM) || CTeamFortress2Mod::isMapType(TF_MAP_SD) || CTeamFortress2Mod::isMapType(TF_MAP_CART) ||
-			CTeamFortress2Mod::isMapType(TF_MAP_CARTRACE) || CTeamFortress2Mod::isMapType(TF_MAP_ARENA) ||
+			CTeamFortress2Mod::isMapType(TF_MAP_CARTRACE) || CTeamFortress2Mod::isMapType(TF_MAP_ARENA) || CTeamFortress2Mod::isMapType(TF_MAP_SAXTON) ||
 			CTeamFortress2Mod::isMapType(TF_MAP_KOTH) || CTeamFortress2Mod::isMapType(TF_MAP_CP) || CTeamFortress2Mod::isMapType(TF_MAP_CPPL) ||
 			CTeamFortress2Mod::isMapType(TF_MAP_TC)),
 			fDefendFlagUtility + 0.4f)

--- a/utils/RCBot2_meta/bot_mods.h
+++ b/utils/RCBot2_meta/bot_mods.h
@@ -807,7 +807,6 @@ typedef enum : std::uint8_t
 	TF_MAP_CART,
 	TF_MAP_CARTRACE,
 	TF_MAP_ARENA,
-	TF_MAP_SAXTON,
 	TF_MAP_KOTH,
 	TF_MAP_SD, // special delivery : added 15 jul 12
 	TF_MAP_TR,

--- a/utils/RCBot2_meta/bot_mods.h
+++ b/utils/RCBot2_meta/bot_mods.h
@@ -808,6 +808,7 @@ typedef enum : std::uint8_t
 	TF_MAP_CARTRACE,
 	TF_MAP_ARENA,
 	TF_MAP_SAXTON,
+	TF_MAP_PIPELINE,
 	TF_MAP_KOTH,
 	TF_MAP_SD, // special delivery : added 15 jul 12
 	TF_MAP_TR,

--- a/utils/RCBot2_meta/bot_mods.h
+++ b/utils/RCBot2_meta/bot_mods.h
@@ -807,6 +807,7 @@ typedef enum : std::uint8_t
 	TF_MAP_CART,
 	TF_MAP_CARTRACE,
 	TF_MAP_ARENA,
+	TF_MAP_SAXTON,
 	TF_MAP_KOTH,
 	TF_MAP_SD, // special delivery : added 15 jul 12
 	TF_MAP_TR,

--- a/utils/RCBot2_meta/bot_tf2_mod.cpp
+++ b/utils/RCBot2_meta/bot_tf2_mod.cpp
@@ -715,7 +715,7 @@ edict_t *CTeamFortress2Mod :: getTeleporterExit (const edict_t *pTele)
 // check if the entity is a health kit
 bool CTeamFortress2Mod :: isHealthKit (const edict_t* pEntity)
 {
-	if (CTeamFortress2Mod::isMapType(TF_MAP_SAXTON))
+	if (CTeamFortress2Mod::isMapType(TF_MAP_SAXTON) || isMapType(TF_MAP_ZI))
 	{
 		return false;
 	}

--- a/utils/RCBot2_meta/bot_tf2_mod.cpp
+++ b/utils/RCBot2_meta/bot_tf2_mod.cpp
@@ -127,7 +127,7 @@ Vector CTeamFortress2Mod::m_vNearestTankLocation = Vector(0, 0, 0);
 bool CTeamFortress2Mod::isSuddenDeath()
 {
 	// Bot weapon Randomizer -- leonardo
-	if (!mp_stalemate_enable.IsValid() || !mp_stalemate_enable.GetBool() || isMapType(TF_MAP_ARENA))
+	if (!mp_stalemate_enable.IsValid() || !mp_stalemate_enable.GetBool() || isMapType(TF_MAP_ARENA) || isMapType(TF_MAP_SAXTON))
 		return false;
 
 	if (void *pGameRules = GetGameRules())
@@ -270,10 +270,12 @@ void CTeamFortress2Mod :: mapInit ()
 		m_MapType = TF_MAP_CART; // pipeline
 	else if (std::strncmp(szmapname, "plr_", 4) == 0 || std::strncmp(szmapname, "arena_tinyrock", 14) == 0 || std::strncmp(szmapname, "arena_hailstone", 15) == 0) // to make bots push payloads on these maps. - RussiaTails
 		m_MapType = TF_MAP_CARTRACE; // pipeline racing
-	else if (std::strncmp(szmapname, "arena_", 6) == 0 || std::strncmp(szmapname, "vsh_", 4) == 0)  // pongo1321
-		m_MapType = TF_MAP_ARENA; // arena mode (also fallback for VS Saxton Hale gamemode)
-	//else if ( std::strncmp(szmapname,"arena_",6) == 0 )
-	//	m_MapType = TF_MAP_ARENA; // arena mode
+	else if (std::strncmp(szmapname, "arena_", 6) == 0 )  // pongo1321
+		m_MapType = TF_MAP_ARENA; // arena mode
+	else if (std::strncmp(szmapname, "vsh_", 4) == 0 )
+		m_MapType = TF_MAP_SAXTON; // versus saxton hale mode
+	else if (std::strncmp(szmapname, "pipeball_", 9) == 0)
+		m_MapType = TF_MAP_PIPEBALL; // pipeball
 	else if (std::strncmp(szmapname, "koth_", 5) == 0 || std::strncmp(szmapname, "ctk_", 4) == 0)  // Control the Keep works almost the same as KOTH. - RussiaTails
 		m_MapType = TF_MAP_KOTH; // king of the hill
 	else if (std::strncmp(szmapname, "sd_", 3) == 0 || std::strncmp(szmapname, "sdr_", 4) == 0)  // Object Destruction and Special Delivery Race (I dunno why it's named like this when it works as a usual sd_) works the same as SD_. - RussiaTails
@@ -543,7 +545,7 @@ bool CTeamFortress2Mod ::isBoss (edict_t *pEntity, float *fFactor)
 		}
 	}
 	else if (CTeamFortress2Mod::isMapType(TF_MAP_CARTRACE) || isMapType(TF_MAP_CART) || isMapType(TF_MAP_KOTH) || isMapType(TF_MAP_PASS)
-		|| isMapType(TF_MAP_CP) || isMapType(TF_MAP_PD) || isMapType(TF_MAP_ARENA) || isMapType(TF_MAP_SD) || isMapType(TF_MAP_DM))
+		|| isMapType(TF_MAP_CP) || isMapType(TF_MAP_PD) || isMapType(TF_MAP_ARENA) || isMapType(TF_MAP_SAXTON) || isMapType(TF_MAP_SD) || isMapType(TF_MAP_DM))
 	{
 		if ( m_pBoss.get() == pEntity )
 			return true;
@@ -555,6 +557,27 @@ bool CTeamFortress2Mod ::isBoss (edict_t *pEntity, float *fFactor)
 			return true;
 		}
 		
+	}
+	else if (CTeamFortress2Mod::isMapType(TF_MAP_PIPEBALL))
+	{
+		if (m_pBoss.get() == pEntity)
+			return true;
+		if (std::strcmp(pEntity->GetClassName(), "tf_zombie") == 0 ||
+			std::strcmp(pEntity->GetClassName(), "func_physbox") == 0 ||
+			std::strcmp(pEntity->GetClassName(), "base_boss") == 0)
+		{
+			m_pBoss = pEntity;
+			return true;
+		}
+		if (isTankBoss(pEntity))
+		{
+			if (fFactor != nullptr)
+				*fFactor = 200.0f;
+
+			m_pBoss = pEntity;
+			return true;
+		}
+
 	}
 	else if ( CTeamFortress2Mod::isMapType(TF_MAP_MVM) )
 	{
@@ -692,7 +715,11 @@ edict_t *CTeamFortress2Mod :: getTeleporterExit (const edict_t *pTele)
 // check if the entity is a health kit
 bool CTeamFortress2Mod :: isHealthKit (const edict_t* pEntity)
 {
-	return std::strncmp(pEntity->GetClassName(),"item_healthkit",14) == 0;
+	if (CTeamFortress2Mod::isMapType(TF_MAP_SAXTON))
+	{
+		return false;
+	}
+	return std::strncmp(pEntity->GetClassName(),"item_healthkit",14)==0;
 }
 
 bool CTeamFortress2Mod :: isAreaOwnedByTeam (const int iArea, const int iTeam)


### PR DESCRIPTION
For Pipeball gamemode was added an entity target for bots to attack (Experimental).
For Versus Saxton Hale gamemode was added these changes:
1) Gamemode has it's own MapType
2) Removed item_healthkit entity recognition for bots in VSH maps only but they still recognise health waypoint type
3) Added noXteam function recognition with health and ammo waypoint types
These changes for VSH were done to avoid Hale stubborn trying to heal himself with medkits