### PR TITLE
dod bug fixes

### DIFF
--- a/utils/RCBot2_meta/bot_dod_bot.cpp
+++ b/utils/RCBot2_meta/bot_dod_bot.cpp
@@ -326,6 +326,9 @@ bool CDODBot :: startGame ()
 	if ( (m_iDesiredClass < 0) || (m_iDesiredClass > 5) )
 		chooseClass(false);
 
+	if (CClassInterface::getPlayerClassDOD(m_pEdict) < 0)
+		return false;
+
 	// not the correct class? and desired class is valid?
 	if ( (m_iDesiredClass >= 0) && (m_iDesiredClass <= 5) && (m_iDesiredClass != CClassInterface::getPlayerClassDOD(m_pEdict)) )
 	{

--- a/utils/RCBot2_meta/bot_task.cpp
+++ b/utils/RCBot2_meta/bot_task.cpp
@@ -1639,7 +1639,10 @@ void CBotInvestigateTask :: execute (CBot *pBot,CBotSchedule *pSchedule)
 	}
 
 	if ( m_fTime < engine->Time() )
+	{
 		complete();
+		return;
+	}
 
 	if (!m_InvPoints.empty())
 	{


### PR DESCRIPTION
### * [Stop processing investigate task after complete](https://github.com/APGRoboCop/rcbot2/commit/4d23aa44a7a77b72fde2ca9910cc6230fc8c1448)

In `CBotInvestigateTask` if the maximum time is reached, then the task state is set to complete.  Without the return, it can potentially continue to `pBot->setMoveTo(vPoint);` but `vPoint` is only ever defined if the task state is idle or running.   

If the undefined pointer container contains a NaN (it doesn't always) that is then propagated through the movement calculations and ultimately results in the game teleporting the bot to the origin.

[Anonymous Player — 6/18/25, 10:21 PM](https://discord.com/channels/323526874200276994/323526874200276994/1384870693107269742)
> The game sets the player's velocity and/or position to zero if it's a bogus value.
>
> https://github.com/ValveSoftware/source-sdk-2013/blob/39f6dde8fbc238727c020d13b05ecadd31bda4c0/src/game/shared/gamemovement.cpp#L3048-L3086

### * [Don't try and change class while class is undefined](https://github.com/APGRoboCop/rcbot2/commit/2666e4bfb7dd05dfc9b0024cdee49398464c7465)

If a bot joins during the end game freeze, usually because a human player left at the end of the round, then it crashes the server.

```
2025-09-03T04:53:49.772925053Z [RCBOT2] Hook_ClientActive(21, 0)
2025-09-03T04:53:50.080957262Z #GameUI_Disconnect_TooManyCommands
2025-09-03T04:53:50.081883275Z [RCBOT2] Hook_ClientDisconnect(21)
2025-09-03T04:53:50.082421977Z Dropped Kenneth-Spanks from server (#GameUI_Disconnect_TooManyCommands)
2025-09-03T04:53:50.177303178Z crash_20250903045350_2.dmp[687]: Uploading dump (out-of-process)
2025-09-03T04:53:50.177335146Z /tmp/dumps/crash_20250903045350_2.dmp
2025-09-03T04:53:50.177340351Z crash_20250903045350_2.dmp[687]: Uploading dump (out-of-process)
2025-09-03T04:53:50.177343886Z /tmp/dumps/crash_20250903045350_2.dmp
```

This is because it spins through `startGame` -> `changeClass` again and again on every `think` loop, sending a class command to the server each time.   Because we're in the end game freeze, the class command isn't processed and so we send another on the next loop.   This continues until the server forces a disconnect for sending too many commands too quickly - although this can be masked by setting a very high `sv_quota_stringcmdspersecond`.

Once the client has been disconnected and is no longer valid, the `getTeam` call in `changeClass` results in a crash - see the trace below.

To avoid this, in startGame,  don't try and change class until the game is ready to process our class.  

```
Crash reason:  SIGSEGV
Crash address: 0x00000000
Process uptime: not available

Linux memory map count: 376

Thread 0  (crashed) - tid: 88
 0  rcbot.2.dods.so!CBot::getTeam() [bot.cpp : 1730 + 0x6]
     eip = 0xdfb87b2d    esp = 0xffd490e0    ebp = 0xffd490e8    ebx = 0xdfea4ff4
     esi = 0x08c6aff0    edi = 0x00000001    eax = 0x0921dc20    ecx = 0x00000000
     edx = 0x00000001 eflags = 0x00010292
    Found by: given as instruction pointer in context
 1  rcbot.2.dods.so!CDODBot::changeClass() [bot_dod_bot.cpp : 1041 + 0x7]
     eip = 0xdfbdc469    esp = 0xffd490f0    ebp = 0xffd49138    ebx = 0xdfea4ff4
     esi = 0x08c6aff0    edi = 0x00000001
    Found by: call frame info
 2  rcbot.2.dods.so!CDODBot::startGame() [bot_dod_bot.cpp : 333 + 0x7]
     eip = 0xdfbdbff0    esp = 0xffd49140    ebp = 0xffd49168    ebx = 0xdfea4ff4
     esi = 0x08c6aff0    edi = 0x00000001
    Found by: call frame info
 3  rcbot.2.dods.so!CBot::think() [bot.cpp : 808 + 0x7]
     eip = 0xdfb82c01    esp = 0xffd49170    ebp = 0xffd49268    ebx = 0xdfea4ff4
     esi = 0x08c6aff0    edi = 0x00000001
    Found by: call frame info
 4  rcbot.2.dods.so!CBots::botThink() [bot.cpp : 3395 + 0xd]
     eip = 0xdfb8cb18    esp = 0xffd49270    ebp = 0xffd49298    ebx = 0xdfea4ff4
     esi = 0x08c6aff0    edi = 0x00000001
    Found by: call frame info
 5  rcbot.2.dods.so!RCBotPluginMeta::Hook_GameFrame(bool) [bot_plugin_meta.cpp : 814 + 0x4]
     eip = 0xdfcc59de    esp = 0xffd492a0    ebp = 0xffd492b8    ebx = 0xdfea4ff4
     esi = 0x08c6aff0    edi = 0x00000001
    Found by: call frame info
 6  rcbot.2.dods.so!fastdelegate::FastDelegate<void, bool>::operator()(bool) const [FastDelegate.h : 927 + 0x77]
     eip = 0xdfccc94f    esp = 0xffd492c0    ebp = 0xffd492f8    ebx = 0xdfea4ff4
     esi = 0x08c6aff0    edi = 0x00000001
    Found by: call frame info
 7  rcbot.2.dods.so!__SourceHook_FHCls_IServerGameDLLGameFrame0::CMyDelegateImpl::Call(bool) [bot_plugin_meta.cpp : 75 + 0x37]
     eip = 0xdfccc828    esp = 0xffd49300    ebp = 0xffd49318    ebx = 0xdfea4ff4
     esi = 0x08c6aff0    edi = 0x00000001
    Found by: call frame info
 8  sourcemod.2.dods.so + 0x4d70f
```



