### PR TITLE
Changes to config options for add/kick bot behavior

### DIFF
--- a/package/config/config.ini
+++ b/package/config/config.ini
@@ -201,9 +201,26 @@ rcbot_move_obj 1
 # For more information see bot_quota.ini
 rcbot_bot_quota_interval -1
 #
-# Or use these settings (but dont use them together with the above setting!)
+# If quota is enabled then min and max are treated as a ceiling and floor for bot numbers.
+# If quota is disabled then these become the primary logic for deciding bot numbers.
 rcbotd config min_bots -1
 rcbotd config max_bots 10
+#
+# If enabled, only concider humans who are actively playing - ie; are on a team
+# Caution: if max_bots is too high it's possible to have teams full of bots and humans
+# be unable to join since bots will no longer disconnect as soon as players join the server
+#rcbot_ignore_spectators 0
+#
+# When reducing the number of bots, instead of kicking a randomly chosen bot, kick the most
+# recently added bot.  If teams are unequal, only concider bots from the larger team.
+#rcbot_nonrandom_kicking 0
+#
+# When adding a bot, instead of using a randomly chosen profile, treat the profiles as
+# an ordered list, loading bot 1 first, bot 2 second and so on.   If teams are unequal,
+# only concider bots who either have no team preference, or who's team profile is for
+# the smaller team.   If no suitable bot can be found, fall back to choosing one randomly.
+#rcbot_nonrandom_profile 0
+#
 # These plugins conflict and may not work well with RCBot2. Please inform us for any plugins that
 # conflicts or prevents RCBot2 from working in rcbot.bots-united.com
 # The plugins that have been commented are considered greylisted as they aren't guaranteed to work						 

--- a/package/config/default_cfg.txt
+++ b/package/config/default_cfg.txt
@@ -198,9 +198,25 @@ rcbot_move_obj 1
 # For more information see bot_quota.ini
 rcbot_bot_quota_interval -1
 #
-# Or use these settings (but dont use them together with the above setting!)
+# If quota is enabled then min and max are treated as a ceiling and floor for bot numbers.
+# If quota is disabled then these become the primary logic for deciding bot numbers.
 rcbotd config min_bots -1
 rcbotd config max_bots 10
+#
+# If enabled, only concider humans who are actively playing - ie; are on a team
+# Caution: if max_bots is too high it's possible to have teams full of bots and humans
+# be unable to join since bots will no longer disconnect as soon as players join the server
+#rcbot_ignore_spectators 0
+#
+# When reducing the number of bots, instead of kicking a randomly chosen bot, kick the most
+# recently added bot.  If teams are unequal, only concider bots from the larger team.
+#rcbot_nonrandom_kicking 0
+#
+# When adding a bot, instead of using a randomly chosen profile, treat the profiles as
+# an ordered list, loading bot 1 first, bot 2 second and so on.   If teams are unequal,
+# only concider bots who either have no team preference, or who's team profile is for
+# the smaller team.   If no suitable bot can be found, fall back to choosing one randomly.
+#rcbot_nonrandom_profile 0
 #
 # These plugins conflict and may not work well with RCBot2. Please inform us for any plugins that
 # conflicts or prevents RCBot2 from working in rcbot.bots-united.com

--- a/utils/RCBot2_meta/bot.cpp
+++ b/utils/RCBot2_meta/bot.cpp
@@ -3659,6 +3659,38 @@ void CBots :: kickRandomBot (const unsigned count)
 	m_flAddKickBotTime = engine->Time() + 2.0f;
 }
 
+void CBots::kickChosenBotOnTeam(const int team)
+{
+	std::vector<CBot*> botList;
+	//gather list of bots
+	for ( unsigned i = 0; i < RCBOT_MAXPLAYERS; i ++ )
+	{
+		if ( m_Bots[i]->inUse() && m_Bots[i]->getTeam() == team)
+			botList.emplace_back(m_Bots[i]);
+	}
+
+	if ( botList.empty() )
+	{
+		logger->Log(LogLevel::DEBUG, "kickChosenBotOnTeam() : No bots to kick");
+		return;
+	}
+
+	CBot* pBot = nullptr;
+	for (CBot* tBot : botList) {
+		if ((pBot == nullptr) || ( pBot->getCreateTime() < tBot->getCreateTime() ))
+			pBot = tBot;
+	}
+
+	logger->Log(LogLevel::DEBUG, "kickChosenBotOnTeam() : kicking %s, created at %0.2f", pBot->getBotName(), pBot->getCreateTime());
+
+	char szCommand[512];
+
+	snprintf(szCommand, sizeof(szCommand), "kickid %d\n", pBot->getPlayerID());
+	engine->ServerCommand(szCommand);
+
+	m_flAddKickBotTime = engine->Time() + 2.0f;
+}
+
 void CBots::kickRandomBotOnTeam(const int team)
 {
 	std::vector<int> botList;

--- a/utils/RCBot2_meta/bot.cpp
+++ b/utils/RCBot2_meta/bot.cpp
@@ -3681,8 +3681,6 @@ void CBots::kickChosenBotOnTeam(const int team)
 			pBot = tBot;
 	}
 
-	logger->Log(LogLevel::DEBUG, "kickChosenBotOnTeam() : kicking %s, created at %0.2f", pBot->getBotName(), pBot->getCreateTime());
-
 	char szCommand[512];
 
 	snprintf(szCommand, sizeof(szCommand), "kickid %d\n", pBot->getPlayerID());

--- a/utils/RCBot2_meta/bot.cpp
+++ b/utils/RCBot2_meta/bot.cpp
@@ -3139,7 +3139,7 @@ bool CBots::controlBot(const char* szOldName, const char* szName, const char* sz
 		return false;
 	}
 
-	if (m_iMaxBots != -1 && CBotGlobals::numClients() >= m_iMaxBots)
+	if (m_iMaxBots != -1 && CBotGlobals::numPlayersPlaying() >= m_iMaxBots)
 	{
 		logger->Log(LogLevel::ERROR, "Can't create bot, max_bots reached");
 		return false;
@@ -3173,12 +3173,17 @@ bool CBots :: createBot (const char *szClass, const char *szTeam, const char *sz
 	CBotMod *pMod = CBotGlobals::getCurrentMod(); // `*pMod` Unused? [APG]RoboCop[CL]
 	const char *szOVName = ""; // `szOVName` Unused? [APG]RoboCop[CL]
 
-	if ( m_iMaxBots != -1 && CBotGlobals::numClients() >= m_iMaxBots )
+	if ( m_iMaxBots != -1 && CBotGlobals::numPlayersPlaying() >= m_iMaxBots )
 		logger->Log(LogLevel::ERROR, "Can't create bot, max_bots reached");
 
 	m_flAddKickBotTime = engine->Time() + rcbot_addbottime.GetFloat();
 
-	CBotProfile* pBotProfile = CBotProfiles::getRandomFreeProfile();
+	CBotProfile* pBotProfile;
+	if (rcbot_nonrandom_profile.GetBool()) {
+		pBotProfile = CBotProfiles::getChosenFreeProfile();
+	} else {
+		pBotProfile = CBotProfiles::getRandomFreeProfile();
+	}
 
 	if ( pBotProfile == nullptr)
 	{
@@ -3428,7 +3433,11 @@ void CBots :: botThink ()
 	}
 	else if ( needToKickBot () )
 	{
-		kickRandomBot();
+		if (rcbot_nonrandom_kicking.GetBool()) {
+			kickChosenBot();
+		} else {
+			kickRandomBot();
+		}
 	}
 }
 
@@ -3511,23 +3520,104 @@ void CBots :: mapInit ()
 
 bool CBots :: needToAddBot ()
 {
-	const int iClients = CBotGlobals::numClients();
+	if (rcbot_bot_quota_interval.GetFloat() > 0.0) {
+		return false;
+	}
 
-	return (m_iMinBots!=-1 && CBots::numBots() < m_iMinBots) || (iClients < m_iMaxBots && m_iMaxBots != -1);
+	const int iClients = CBotGlobals::numPlayersPlaying();
+	const int iBots = CBots::numBots();
+
+	if ((m_iMinBots!=-1 && iBots < m_iMinBots) || (iClients < m_iMaxBots && m_iMaxBots != -1)) {
+		return true;
+	}
+
+	return false;
 }
 
 bool CBots :: needToKickBot ()
 {
+	if (rcbot_bot_quota_interval.GetFloat() > 0.0) {
+		return false;
+	}
+
+	const int iClients = CBotGlobals::numPlayersPlaying();
+	const int iBots = CBots::numBots();
+
 	if ( m_flAddKickBotTime < engine->Time() )
 	{
-		if ( m_iMinBots != -1 && CBots::numBots() <= m_iMinBots )
+		if ( m_iMinBots != -1 && iBots <= m_iMinBots )
 			return false;
 
-		if ( m_iMaxBots > 0 && CBotGlobals::numClients() > m_iMaxBots )
+		if ( m_iMaxBots > 0 && iClients > m_iMaxBots ) {
 			return true;
+		}
 	}
 
 	return false;
+}
+
+void CBots :: kickChosenBot (const unsigned count)
+{
+        std::vector<CBot*> botList;
+        //gather list of bots
+        for ( unsigned i = 0; i < RCBOT_MAXPLAYERS; i ++ )
+        {
+		if ( m_Bots[i]->inUse() )
+			botList.emplace_back(m_Bots[i]);
+        }
+
+        if ( botList.empty() )
+        {
+                logger->Log(LogLevel::DEBUG, "kickChosenBot() : No bots to kick");
+                return;
+        }
+
+	int team = 0;
+	int teamA = CBotGlobals::numPlayersOnTeam(2,false);
+	int teamB = CBotGlobals::numPlayersOnTeam(3,false);
+
+	CBot* pBot;
+	unsigned numBotsKicked = 0;
+	while (numBotsKicked < count && !botList.empty()) {
+		// check numBotsOnTeam in case all the remaining bots are on the smaller team
+		if ((teamA > teamB) && (CBotGlobals::numBotsOnTeam(2,false) > 0)) {
+			team = 2;
+		} else if ((teamA < teamB) && (CBotGlobals::numBotsOnTeam(3,false) > 0)) {
+			team = 3;
+		} else {
+			team = 0;
+		}
+
+		pBot = nullptr;
+		for (CBot* tBot : botList) {
+			if ((team < 2) || (tBot->getTeam() == team)) {
+				if ((pBot == nullptr) || ( pBot->getCreateTime() < tBot->getCreateTime() ))
+					pBot = tBot;
+			}
+		}
+
+		if (pBot == nullptr) {
+			logger->Log(LogLevel::DEBUG, "kickChosenBot() : No bot to kick");
+			return;
+		}
+
+		if (pBot->getTeam() == 2)
+			teamA--;
+		else if (pBot->getTeam() == 3)
+			teamB--;
+
+		char szCommand[512];
+
+		snprintf(szCommand, sizeof(szCommand), "kickid %d\n", pBot->getPlayerID());
+		engine->ServerCommand(szCommand);
+
+		botList.erase(std::remove(botList.begin(), botList.end(), pBot),
+			botList.end());
+
+		numBotsKicked++;
+	}
+
+	m_flAddKickBotTime = engine->Time() + 2.0f;
 }
 
 void CBots :: kickRandomBot (const unsigned count)

--- a/utils/RCBot2_meta/bot.h
+++ b/utils/RCBot2_meta/bot.h
@@ -391,6 +391,11 @@ public:
 
 	virtual int getTeam ();
 
+	float getCreateTime() const
+	{
+		return m_fTimeCreated;
+	}
+
 	bool isUnderWater ( ) const;
 
 	CBotWeapon *getBestWeapon ( edict_t *pEnemy, bool bAllowMelee = true, bool bAllowMeleeFallback = true, bool bMeleeOnly = false, bool bExplosivesOnly = false ) const;
@@ -1080,6 +1085,7 @@ public:
 
 	static void roundStart ();
 
+	static void kickChosenBot (unsigned count = 1);
 	static void kickRandomBot (unsigned count = 1);
 	static void kickRandomBotOnTeam ( int team );
 
@@ -1093,6 +1099,8 @@ public:
 
 	static void setMinBots (const int iMin) { m_iMinBots = iMin; }
 	static int getMinBots () { return m_iMinBots; }
+
+	static float getAddKickBotTime() { return m_flAddKickBotTime; }
 
 	static void botFunction ( IBotFunction *function );
 

--- a/utils/RCBot2_meta/bot.h
+++ b/utils/RCBot2_meta/bot.h
@@ -1087,6 +1087,7 @@ public:
 
 	static void kickChosenBot (unsigned count = 1);
 	static void kickRandomBot (unsigned count = 1);
+	static void kickChosenBotOnTeam ( int team );
 	static void kickRandomBotOnTeam ( int team );
 
 	static void mapInit ();

--- a/utils/RCBot2_meta/bot_commands.cpp
+++ b/utils/RCBot2_meta/bot_commands.cpp
@@ -128,14 +128,21 @@ CBotCommandInline KickBotCommand("kickbot", CMD_ACCESS_BOT | CMD_ACCESS_DEDICATE
 {
 	if (!args[0] || !*args[0])
 	{
-		//remove random bot
-		CBots::kickRandomBot();
+		if (rcbot_nonrandom_kicking.GetBool()) {
+			CBots::kickChosenBot();
+		} else {
+			CBots::kickRandomBot();
+		}
 	}
 	else
 	{
 		const int team = std::atoi(args[0]);
 
-		CBots::kickRandomBotOnTeam(team);
+		if (rcbot_nonrandom_kicking.GetBool()) {
+			CBots::kickChosenBotOnTeam(team);
+		} else {
+			CBots::kickRandomBotOnTeam(team);
+		}
 	}
 
 	return COMMAND_ACCESSED;

--- a/utils/RCBot2_meta/bot_cvars.cpp
+++ b/utils/RCBot2_meta/bot_cvars.cpp
@@ -107,6 +107,9 @@ ConVar rcbot_datamap_offset("rcbot_datamap_offset", "0", 0, "offset for datamaps
 ConVar rcbot_bot_quota_interval("rcbot_bot_quota_interval", "10", 0, "Interval between bot quota checks, 0 or lower to disable");
 ConVar rcbot_show_welcome_msg("rcbot_show_welcome_msg", "1", 0, "Show welcome message on player connect");//Not referenced properly? [APG]RoboCop[CL]
 ConVar rcbot_force_class("rcbot_force_class", "0", 0, "Force bots to choose specified class, kills alive bots on change (1 - 9, set to 0 for none)");
+ConVar rcbot_ignore_spectators("rcbot_ignore_spectators", "0", 0, "Ignore spectators when calculating target number of bots");
+ConVar rcbot_nonrandom_kicking("rcbot_nonrandom_kicking", "0", 0, "Choose newest bot from largest team when kicking bots");
+ConVar rcbot_nonrandom_profile("rcbot_nonrandom_profile", "0", 0, "Choose first free bot from profile list when creating bots");
 
 // Synergy CVars
 ConVar rcbot_runplayercmd_syn("rcbot_runplayer_cmd_syn", "424", 0, "offset of the Synergy PlayerRunCommand function");

--- a/utils/RCBot2_meta/bot_cvars.h
+++ b/utils/RCBot2_meta/bot_cvars.h
@@ -104,6 +104,10 @@ extern ConVar rcbot_css_economy_eco_limit;
 extern ConVar rcbot_show_welcome_msg;
 extern ConVar rcbot_force_class;
 
+extern ConVar rcbot_ignore_spectators;
+extern ConVar rcbot_nonrandom_kicking;
+extern ConVar rcbot_nonrandom_profile;
+
 extern ConVarRef sv_gravity;
 extern ConVarRef mp_teamplay;
 extern ConVarRef sv_tags;

--- a/utils/RCBot2_meta/bot_dod_mod.cpp
+++ b/utils/RCBot2_meta/bot_dod_mod.cpp
@@ -891,9 +891,12 @@ int CDODMod ::numClassOnTeam(const int iTeam, const int iClass)
 {
 	int num = 0;
 
-	for ( int i = 1; i <= CBotGlobals::numClients(); i ++ )
+	for ( int i = 1; i <= CBotGlobals::maxClients(); i ++ )
 	{
 		edict_t* pEdict = INDEXENT(i);
+
+		if ( !pEdict )
+			continue;
 
 		if ( CBotGlobals::entityIsValid(pEdict) )
 		{

--- a/utils/RCBot2_meta/bot_globals.cpp
+++ b/utils/RCBot2_meta/bot_globals.cpp
@@ -197,7 +197,6 @@ int CBotGlobals ::numPlayersOnTeam(const int iTeam, const bool bAliveOnly)
 			}
 		}
 	}
-	logger->Log(LogLevel::DEBUG, "numPlayersOnTeam(%d): %d players on team%s", iTeam, num, (iTeam == 2 ? "A" : "B"));
 	return num;
 }
 
@@ -661,7 +660,6 @@ int CBotGlobals :: numClients ()
 		}
 	}
 
-	logger->Log(LogLevel::DEBUG, "numClients(): %d clients, last index: %d", iCount, iIndex);
 	return iCount;
 }
 

--- a/utils/RCBot2_meta/bot_globals.cpp
+++ b/utils/RCBot2_meta/bot_globals.cpp
@@ -147,14 +147,16 @@ bool CBotGlobals :: isCurrentMod (const eModId modid)
 
 int CBotGlobals ::numPlayersPlaying()
 {
-
 	int num = CBotGlobals::numClients();
 
 	if (rcbot_ignore_spectators.GetBool())
 	{
-		for ( int i = 1; i <= CBotGlobals::numClients(); i ++ )
+		for ( int i = 1; i <= CBotGlobals::maxClients(); i ++ )
 		{
 			edict_t* pEdict = INDEXENT(i);
+
+			if ( !pEdict )
+				continue;
 
 			if ( CBotGlobals::entityIsValid(pEdict) )
 			{
@@ -174,9 +176,12 @@ int CBotGlobals ::numPlayersOnTeam(const int iTeam, const bool bAliveOnly)
 {
 	int num = 0;
 
-	for ( int i = 1; i <= CBotGlobals::numClients(); i ++ )
+	for ( int i = 1; i <= CBotGlobals::maxClients(); i ++ )
 	{
 		edict_t* pEdict = INDEXENT(i);
+
+		if ( !pEdict )
+			continue;
 
 		if ( CBotGlobals::entityIsValid(pEdict) )
 		{
@@ -192,6 +197,7 @@ int CBotGlobals ::numPlayersOnTeam(const int iTeam, const bool bAliveOnly)
 			}
 		}
 	}
+	logger->Log(LogLevel::DEBUG, "numPlayersOnTeam(%d): %d players on team%s", iTeam, num, (iTeam == 2 ? "A" : "B"));
 	return num;
 }
 
@@ -199,9 +205,12 @@ int CBotGlobals ::numBotsOnTeam(const int iTeam, const bool bAliveOnly)
 {
 	int num = 0;
 
-	for ( int i = 1; i <= CBotGlobals::numClients(); i ++ )
+	for ( int i = 1; i <= CBotGlobals::maxClients(); i ++ )
 	{
 		edict_t* pEdict = INDEXENT(i);
+
+		if ( !pEdict )
+			continue;
 
 		if ( CBotGlobals::entityIsValid(pEdict) && CBots::getBotPointer(pEdict) != NULL )
 		{
@@ -633,6 +642,7 @@ int CBotGlobals :: countTeamMatesNearOrigin (const Vector& vOrigin, const float 
 int CBotGlobals :: numClients ()
 {
 	int iCount = 0;
+	int iIndex = 0;
 
 	for ( int i = 1; i <= CBotGlobals::maxClients(); i ++ )
 	{
@@ -640,15 +650,18 @@ int CBotGlobals :: numClients ()
 
 		if ( !pEdict )
 			continue;
-		
+
 		IPlayerInfo *p = playerinfomanager->GetPlayerInfo(pEdict);
 		if (!p || p->IsHLTV())
 			continue;
 		
-		if ( engine->GetPlayerUserId(pEdict) > 0 )
+		if ( engine->GetPlayerUserId(pEdict) > 0 ) {
+			iIndex = i;
 			iCount++;
+		}
 	}
 
+	logger->Log(LogLevel::DEBUG, "numClients(): %d clients, last index: %d", iCount, iIndex);
 	return iCount;
 }
 

--- a/utils/RCBot2_meta/bot_globals.cpp
+++ b/utils/RCBot2_meta/bot_globals.cpp
@@ -145,6 +145,31 @@ bool CBotGlobals :: isCurrentMod (const eModId modid)
 	return m_pCurrentMod->getModId() == modid;
 }
 
+int CBotGlobals ::numPlayersPlaying()
+{
+
+	int num = CBotGlobals::numClients();
+
+	if (rcbot_ignore_spectators.GetBool())
+	{
+		for ( int i = 1; i <= CBotGlobals::numClients(); i ++ )
+		{
+			edict_t* pEdict = INDEXENT(i);
+
+			if ( CBotGlobals::entityIsValid(pEdict) )
+			{
+				if ( CClassInterface::getTeam(pEdict) >= 2 )
+					continue;
+				if ( CBots::getBotPointer(pEdict) != NULL )
+					continue;
+				num--;
+			}
+		}
+	}
+
+	return num;
+}
+
 int CBotGlobals ::numPlayersOnTeam(const int iTeam, const bool bAliveOnly)
 {
 	int num = 0;
@@ -163,6 +188,31 @@ int CBotGlobals ::numPlayersOnTeam(const int iTeam, const bool bAliveOnly)
 						num++;
 				}
 				else 
+					num++;
+			}
+		}
+	}
+	return num;
+}
+
+int CBotGlobals ::numBotsOnTeam(const int iTeam, const bool bAliveOnly)
+{
+	int num = 0;
+
+	for ( int i = 1; i <= CBotGlobals::numClients(); i ++ )
+	{
+		edict_t* pEdict = INDEXENT(i);
+
+		if ( CBotGlobals::entityIsValid(pEdict) && CBots::getBotPointer(pEdict) != NULL )
+		{
+			if ( CClassInterface::getTeam(pEdict) == iTeam )
+			{
+				if ( bAliveOnly )
+				{
+					if ( CBotGlobals::entityIsAlive(pEdict) )
+						num++;
+				}
+				else
 					num++;
 			}
 		}

--- a/utils/RCBot2_meta/bot_globals.h
+++ b/utils/RCBot2_meta/bot_globals.h
@@ -97,7 +97,9 @@ public:
 	static float DotProductFromOrigin ( edict_t *pEnemy, const Vector& pOrigin );
 	static float DotProductFromOrigin (const Vector& vPlayer, const Vector& vFacing, const QAngle& eyes );
 
+	static int numPlayersPlaying();
 	static int numPlayersOnTeam(int iTeam, bool bAliveOnly);
+	static int numBotsOnTeam(int iTeam, bool bAliveOnly);
 	static void setMapName ( const char *szMapName );
 	static char *getMapName (); 
 

--- a/utils/RCBot2_meta/bot_plugin_meta.cpp
+++ b/utils/RCBot2_meta/bot_plugin_meta.cpp
@@ -834,7 +834,7 @@ void RCBotPluginMeta::Hook_GameFrame(const bool simulating)
 		currentmod->modFrame();
 
 		// Bot Quota
-		if (rcbot_bot_quota_interval.GetInt() > 0) {
+		if (rcbot_bot_quota_interval.GetFloat() > 0.0) {
 			BotQuotaCheck();
 		}
 	}
@@ -842,7 +842,7 @@ void RCBotPluginMeta::Hook_GameFrame(const bool simulating)
 
 void RCBotPluginMeta::BotQuotaCheck() {
 	// this is configured with config/bot_quota.ini
-	if (rcbot_bot_quota_interval.GetInt() <= 0) {
+	if (rcbot_bot_quota_interval.GetFloat() <= 0.0) {
 		return;
 	}
 
@@ -877,7 +877,11 @@ void RCBotPluginMeta::BotQuotaCheck() {
 				IPlayerInfo* p = playerinfomanager->GetPlayerInfo(client->getPlayer());
 
 				if (p->IsConnected() && !p->IsFakeClient() && !p->IsHLTV()) {
-					human_count++;
+					if (rcbot_ignore_spectators.GetBool()) {
+						if ( CClassInterface::getTeam(client->getPlayer()) >= 2 )
+							human_count++;
+					} else
+						human_count++;
 				}
 			}
 		}
@@ -887,19 +891,33 @@ void RCBotPluginMeta::BotQuotaCheck() {
 		}
 
 		// Get Bot Quota
-		const int bot_target = m_iTargetBots[human_count];
+		int bot_target = m_iTargetBots[human_count];
+		const int max_bots = CBots::getMaxBots();
+		const int min_bots = CBots::getMinBots();
+
+		// Use min and max as ceiling and floor
+		if ((max_bots > -1) && (bot_target > max_bots)) {
+			bot_target = max_bots;
+		} else if ((min_bots > -1) && (bot_target < min_bots)) {
+			bot_target = min_bots;
+		}
 
 		// Change Bot Quota
 		if (bot_count > bot_target) {
-			CBots::kickRandomBot(static_cast<unsigned>(bot_count - bot_target));
+			if (rcbot_nonrandom_kicking.GetBool()) {
+				CBots::kickChosenBot(static_cast<unsigned>(bot_count - bot_target));
+			} else {
+				CBots::kickRandomBot(static_cast<unsigned>(bot_count - bot_target));
+			}
 			notify = true;
 		}
-		else if (bot_target > bot_count) {
+		else if ((bot_target > bot_count) && ( CBots::getAddKickBotTime() < engine->Time() )) {
 			const int bot_diff = bot_target - bot_count;
 
 			for (int i = 0; i < bot_diff; ++i) {
 				CBots::createBot("", "", "");
-				//break; // Bug-Fix, only add one bot at a time
+				if (rcbot_addbottime.GetFloat() > 0.0)
+					break;
 			}
 
 			notify = true;

--- a/utils/RCBot2_meta/bot_profile.cpp
+++ b/utils/RCBot2_meta/bot_profile.cpp
@@ -193,3 +193,29 @@ CBotProfile* CBotProfiles::getRandomFreeProfile()
 
 	return freeProfiles[static_cast<std::size_t>(randomInt(0, static_cast<int>(freeProfiles.size()) - 1))];
 }
+
+// return first unused bot, concidering teams if they're unequal
+CBotProfile* CBotProfiles::getChosenFreeProfile()
+{
+	int team = 0;
+	int teamA = CBotGlobals::numPlayersOnTeam(2,false);
+	int teamB = CBotGlobals::numPlayersOnTeam(3,false);
+
+	if (teamA < teamB) {
+		team = 2;
+	} else if (teamA > teamB) {
+		team = 3;
+	} else {
+		team = 0;
+	}
+
+	for (CBotProfile*& m_Profile : m_Profiles)
+	{
+		if ((!CBots::findBotByProfile(m_Profile)) && ((team < 2) || (m_Profile->m_iTeam < 2) || (m_Profile->m_iTeam == team))) {
+			return(m_Profile);
+		}
+	}
+
+	// fall back to random if matching fails
+	return CBotProfiles::getRandomFreeProfile();
+}

--- a/utils/RCBot2_meta/bot_profile.h
+++ b/utils/RCBot2_meta/bot_profile.h
@@ -50,6 +50,7 @@ public:
 
 	// return a profile unused by a bot
 	static CBotProfile *getRandomFreeProfile ();
+	static CBotProfile *getChosenFreeProfile ();
 
 	static CBotProfile *getDefaultProfile ();
 

--- a/utils/RCBot2_meta/bot_tf2_mod.cpp
+++ b/utils/RCBot2_meta/bot_tf2_mod.cpp
@@ -441,9 +441,12 @@ int CTeamFortress2Mod ::numClassOnTeam(const int iTeam, const int iClass)
 {
 	int num = 0;
 
-	for ( int i = 1; i <= CBotGlobals::numClients(); i ++ )
+	for ( int i = 1; i <= CBotGlobals::maxClients(); i ++ )
 	{
 		edict_t* pEdict = INDEXENT(i);
+
+		if ( !pEdict )
+                        continue;
 
 		if ( CBotGlobals::entityIsValid(pEdict) )
 		{


### PR DESCRIPTION
### New config options:

* `rcbot_nonrandom_profile`

When adding a bot, treat profiles as an ordered list.  If profiles contain team config, choose a bot that wants to join the smaller team.

If no suitable profile is found it will fall back to the existing random profile chooser / generator rather than not adding a bot.

 * `rcbot_nonrandom_kicking`

When kicking a bot, choose the bot with the lowest connection time, preferring to kick from the larger team if teams are unequal.

 * `rcbot_ignore_spectators`

Only consider human players that are actually on teams when considering either bots quotas or bot min/max.

NB: if the maximum bot count is set too high, users may be prevented from joining at all.

### Changed config options:

* `rcbot_bot_quota_interval` / `min_bots` / `max_bots`

Allow options to co-exist.   When both are active, `bot_quota.ini` is the primary control for bot numbers, with max_bots and min_bots working as an upper and lower limit.

* `rcbot_bot_quota_interval` / `rcbot_addbottime`

If both are set, honour `rcbot_addbottime` when adding bots via quota check.  Allow for sub-second times when setting `rcbot_bot_quota_interval`.
