### PR TITLE
Match m_pBombs memset to match new 8 bomb max

### DIFF
--- a/utils/RCBot2_meta/bot_mods.h
+++ b/utils/RCBot2_meta/bot_mods.h
@@ -231,7 +231,7 @@ public:
 		m_iNumAlliesBombsOnMap = 0;
 		std::memset(m_bBombPlanted,0,sizeof(bool)*MAX_DOD_FLAGS);
 		std::memset(m_pFlags,0,sizeof(edict_t*)*MAX_DOD_FLAGS);
-		std::memset(m_pBombs,0,sizeof(edict_t*)*MAX_DOD_FLAGS*2);
+		std::memset(m_pBombs,0,sizeof(edict_t*)*MAX_DOD_FLAGS*8);
 
 		for (int& i : m_iWaypoint)
 		{


### PR DESCRIPTION
When we changed it to allow a theoretical 8 bombs per capture point ...

https://github.com/APGRoboCop/rcbot2/commit/84a67ff4c0155add939a33a10f3372886d1554d7

```
edict_t* m_pBombs[MAX_DOD_FLAGS][8];
```

... where we zero out that array on each round start didn't get updated to match.

```
std::memset(m_pBombs,0,sizeof(edict_t*)*MAX_DOD_FLAGS*2);
```

... and now with the changed array size it was only properly resetting the first two capture points and bogus data was carried over from map to map. 